### PR TITLE
fix belongto relationship

### DIFF
--- a/src/Sorts/Strategies/HasManySort.php
+++ b/src/Sorts/Strategies/HasManySort.php
@@ -13,14 +13,16 @@ class HasManySort extends SortAbstract
         /** @var Model $relatedModel */
         $relatedModel = $this->model->{$this->relationName}()->getRelated();
         $foreignKeyKey = $this->model->{$this->relationName}()->getQualifiedForeignKeyName();
-        $localKey = $this->model->{$this->relationName}()->getQualifiedParentKeyName();
+        $localKey = $this->model->{$this->relationName}()->getQualifiedOwnerKeyName();
         $relatedTable = $relatedModel->getTable();
+        $alias = $relatedTable . '_' . 'virtual_sort';
 
         return $this->query->orderBy(
             $relatedModel::query()
-            ->select("{$relatedTable}.{$this->column}")
-            ->whereColumn($localKey, $foreignKeyKey)
-            ->orderByRaw("{$relatedTable}.{$this->column} {$this->direction}")
+            ->from("{$relatedTable} as {$alias}")
+            ->select("{$alias}.{$this->column}")
+            ->whereColumn($alias. '.' .$localKey, $foreignKeyKey)
+            ->orderByRaw("{$alias}.{$this->column} {$this->direction}")
             ->limit(1),
             $this->direction
         );


### PR DESCRIPTION
Add a table alias when sorting to the belongsTo relation. This is to prevent errors when the main table and child table have the same table name.