### PR TITLE
Fix: Use related table alias

### DIFF
--- a/src/Sorts/Strategies/HasOneSort.php
+++ b/src/Sorts/Strategies/HasOneSort.php
@@ -15,11 +15,12 @@ class HasOneSort extends SortAbstract
         $foreignKeyKey = $this->model->{$this->relationName}()->getQualifiedForeignKeyName();
         $localKey = $this->model->{$this->relationName}()->getQualifiedParentKeyName();
         $relatedTable = $relatedModel->getTable();
+        $foreignKeyKeyAlias = str($foreignKeyKey)->replace($relatedTable, $alias);
 
         return $this->query->orderBy(
             $relatedModel::query()
             ->select("{$relatedTable}.{$this->column}")
-            ->whereColumn($localKey, $foreignKeyKey)
+            ->whereColumn($localKeyAlias, $foreignKeyKeyAlias)
             ->orderByRaw("{$relatedTable}.{$this->column} {$this->direction}")
             ->limit(1),
             $this->direction


### PR DESCRIPTION
Update the foreign key table name related when used in `where` fixing failing test  
```
SortableTest::it_can_sort_by_has_one_relationship with data set #0 ('asc')
```